### PR TITLE
Store the total number of plans in `PlannedStmt`.

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -555,6 +555,7 @@ standard_planner(Query *parse, const char *query_string, int cursorOptions,
 	result->relationOids = glob->relationOids;
 	result->invalItems = glob->invalItems;
 	result->paramExecTypes = glob->paramExecTypes;
+	result->plan_nodes_count = glob->lastPlanNodeId + 1;
 	/* utilityStmt should be null, but we might as well copy it */
 	result->utilityStmt = parse->utilityStmt;
 	result->stmt_location = parse->stmt_location;

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -97,6 +97,8 @@ typedef struct PlannedStmt
 	/* statement location in source string (copied from Query) */
 	ParseLoc	stmt_location;	/* start location, or -1 if unknown */
 	ParseLoc	stmt_len;		/* length in bytes; 0 means "rest of string" */
+
+	int         plan_nodes_count; /* indicates the number of plan nodes in the statement */
 } PlannedStmt;
 
 /* macro for fetching the Plan associated with a SubPlan node */


### PR DESCRIPTION
Extensions that use planner/executor hooks can't precisely pre-allocate memory for data structures mirroring the plan as the number of plan nodes is unknown.

This information is effectively collected in the standard planner in the node ID counter but was discarded at the end. This change preserves this information.